### PR TITLE
Add LocalPreciseDateTime

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,9 @@
     "purescript-prelude": "^3.1.1",
     "purescript-strings": "^3.5.0",
     "purescript-tuples": "^4.1.0",
-    "purescript-unicode": "^3.0.2"
+    "purescript-unicode": "^3.0.2",
+    "purescript-profunctor": "^3.2.0",
+    "purescript-numbers": "^5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -72,11 +72,15 @@ parseSubseconds (RFC3339String s) = do
 nanosecond :: RFC3339String -> Maybe Nanosecond
 nanosecond rfcString = parseSubseconds rfcString <|> Just 0 >>= toEnum
 
+fromRFC3339String' :: (RFC3339String -> Maybe LocalDateTime)
+                   -> RFC3339String -> Maybe PreciseDateTime
+fromRFC3339String' f s = do
+  ldt <- f s
+  ns  <- nanosecond s
+  pure $ PreciseDateTime ldt ns
+
 fromRFC3339String :: RFC3339String -> Maybe PreciseDateTime
-fromRFC3339String rfcString = do
-  dateTime <- RFC3339String.toLocalDateTime rfcString
-  ns <- nanosecond rfcString
-  pure $ PreciseDateTime dateTime ns
+fromRFC3339String = fromRFC3339String' (map (map (LocalValue (Locale Nothing zero))) RFC3339String.toDateTime)
 
 toRFC3339String :: PreciseDateTime -> RFC3339String
 toRFC3339String (PreciseDateTime (LocalValue locale dateTime) ns) =

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -72,7 +72,7 @@ nanosecond rfcString = parseSubseconds rfcString <|> Just 0 >>= toEnum
 fromRFC3339String :: RFC3339String -> Maybe PreciseDateTime
 fromRFC3339String rfcString = do
   dateTime <- RFC3339String.toDateTime rfcString
-  ns  <- nanosecond rfcString
+  ns <- nanosecond rfcString
   pure $ PreciseDateTime dateTime ns
 
 toRFC3339String :: PreciseDateTime -> RFC3339String
@@ -82,7 +82,7 @@ toRFC3339String (PreciseDateTime dateTime ns) =
     nanos = Int.toStringAs decimal (unwrap ns)
     leftPadded = leftPadNanoString nanos
   in
-     trim <<< RFC3339String $ beforeDot <> "." <> leftPadded <> "Z"
+    trim <<< RFC3339String $ beforeDot <> "." <> leftPadded <> "Z"
 
 -- | Adjusts a date/time value with a duration offset. `Nothing` is returned
 -- | if the resulting date would be outside of the range of valid dates.

--- a/src/Data/PreciseDateTime/Locale.purs
+++ b/src/Data/PreciseDateTime/Locale.purs
@@ -6,14 +6,12 @@ import Data.DateTime.Locale (LocalValue(..), LocalDateTime)
 import Data.Maybe (Maybe)
 import Data.PreciseDateTime (PreciseDateTime)
 import Data.PreciseDateTime as PDT
-import Data.Profunctor.Strong ((&&&))
 import Data.RFC3339String (RFC3339String(..))
 import Data.RFC3339String as RFC3339String
 import Data.RFC3339String.Format (formatLocale)
 import Data.String (dropRight)
 import Data.Time.PreciseDuration (PreciseDuration)
-import Data.Traversable (sequence, traverse)
-import Data.Tuple (uncurry)
+import Data.Traversable (traverse)
 
 type LocalPreciseDateTime = LocalValue PreciseDateTime
 
@@ -21,9 +19,10 @@ adjust :: PreciseDuration -> LocalPreciseDateTime -> Maybe LocalPreciseDateTime
 adjust = traverse <<< PDT.adjust
 
 fromRFC3339String :: RFC3339String -> Maybe LocalPreciseDateTime
-fromRFC3339String = map (uncurry LocalValue)
-                    <<< sequence
-                    <<< (RFC3339String.toLocale &&& PDT.fromRFC3339String)
+fromRFC3339String = do
+  loc <- RFC3339String.toLocale
+  pdt <- PDT.fromRFC3339String
+  pure $ LocalValue loc <$> pdt
 
 toRFC3339String :: LocalPreciseDateTime -> RFC3339String
 toRFC3339String (LocalValue locale pdt) =

--- a/src/Data/PreciseDateTime/Locale.purs
+++ b/src/Data/PreciseDateTime/Locale.purs
@@ -1,0 +1,39 @@
+module Data.PreciseDateTime.Locale where
+
+import Prelude
+
+import Data.DateTime.Locale (LocalValue(..), LocalDateTime)
+import Data.Maybe (Maybe)
+import Data.PreciseDateTime (PreciseDateTime)
+import Data.PreciseDateTime as PDT
+import Data.Profunctor.Strong ((&&&))
+import Data.RFC3339String (RFC3339String(..))
+import Data.RFC3339String as RFC3339String
+import Data.RFC3339String.Format (formatLocale)
+import Data.String (dropRight)
+import Data.Time.PreciseDuration (PreciseDuration)
+import Data.Traversable (sequence, traverse)
+import Data.Tuple (uncurry)
+
+type LocalPreciseDateTime = LocalValue PreciseDateTime
+
+adjust :: PreciseDuration -> LocalPreciseDateTime -> Maybe LocalPreciseDateTime
+adjust = traverse <<< PDT.adjust
+
+fromRFC3339String :: RFC3339String -> Maybe LocalPreciseDateTime
+fromRFC3339String = map (uncurry LocalValue)
+                    <<< sequence
+                    <<< (RFC3339String.toLocale &&& PDT.fromRFC3339String)
+
+toRFC3339String :: LocalPreciseDateTime -> RFC3339String
+toRFC3339String (LocalValue locale pdt) =
+  let
+    (RFC3339String s) = PDT.toRFC3339String pdt
+  in
+    RFC3339String $ dropRight 1 s <> formatLocale locale
+
+toLocalDateTimeLossy :: LocalPreciseDateTime -> LocalDateTime
+toLocalDateTimeLossy = map PDT.toDateTimeLossy
+
+fromLocalDateTime :: LocalDateTime -> LocalPreciseDateTime
+fromLocalDateTime = map PDT.fromDateTime

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad.Eff (runPure)
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
-import Data.DateTime (DateTime(..))
+import Data.DateTime (DateTime)
 import Data.DateTime.Locale (LocalDateTime, LocalValue(..), Locale(..))
 import Data.Foldable (foldr)
 import Data.Formatter.DateTime (format)

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -34,25 +34,19 @@ instance showRFC3339String :: Show RFC3339String where
   show (RFC3339String s) = "(RFC3339String " <> show s <> ")"
 
 -- | Remove trailing zeros from the subsecond component.
-trim :: String -> String
-trim s =
+trim :: RFC3339String -> RFC3339String
+trim (RFC3339String s) =
   let
     withoutZulu = dropWhileEnd (eq 'Z') s
     withoutTrailingZeros = dropWhileEnd (eq '0') withoutZulu
     withoutTrailingDot = dropWhileEnd (eq '.') withoutTrailingZeros
   in
-    withoutTrailingDot
+    RFC3339String $ withoutTrailingDot <> "Z"
 
 -- | Use our own formatter since we'd otherwise need to convert from `DateTime`
 -- | to `JSDate` first, and `Data.JSDate.toISOString` can throw exceptions.
-fromLocalDateTime :: LocalDateTime -> RFC3339String
-fromLocalDateTime = RFC3339String <<< fmt
-  where
-    fmt (LocalValue locale dt) = trim (format iso8601Format dt)
-                              <> formatLocale locale
-
 fromDateTime :: DateTime -> RFC3339String
-fromDateTime = fromLocalDateTime <<< LocalValue (Locale Nothing zero)
+fromDateTime = trim <<< RFC3339String <<< format iso8601Format
 
 -- | Reads the locale, returning GMT (+0000) if not present.
 toLocale :: RFC3339String -> Locale

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -4,18 +4,25 @@ import Prelude
 
 import Control.Monad.Eff (Eff, runPure)
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
+import Data.BigInt (fromInt)
 import Data.DateTime (DateTime)
 import Data.DateTime.Locale (LocalDateTime, LocalValue(..), Locale(..))
+import Data.Either (hush)
 import Data.Foldable (foldr)
 import Data.Formatter.DateTime (format)
+import Data.Int (fromString, toNumber)
 import Data.JSDate (JSDate, LOCALE, getHours, getMinutes, getUTCHours, getUTCMinutes)
 import Data.JSDate as JSDate
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.RFC3339String.Format (formatLocale, iso8601Format)
 import Data.String as String
+import Data.String.Regex as RE
+import Data.String.Regex.Flags (noFlags) as RE
 import Data.Time.Duration (Hours(..), Minutes(..), convertDuration)
+import Data.Traversable (sequence)
 import Data.Tuple (Tuple(..), snd)
+import Partial.Unsafe (unsafePartial)
 
 newtype RFC3339String = RFC3339String String
 
@@ -46,6 +53,17 @@ fromLocalDateTime = RFC3339String <<< fmt
 
 fromDateTime :: DateTime -> RFC3339String
 fromDateTime = fromLocalDateTime <<< LocalValue (Locale Nothing zero)
+
+-- | Reads the locale, returning GMT (+0000) if not present.
+toLocale :: RFC3339String -> Locale
+toLocale (RFC3339String s) = Locale Nothing $ fromMaybe zero $ unsafePartial $ do
+  re <- hush $ RE.regex "([-|\\+])(\\d\\d):?(\\d\\d)$" RE.noFlags
+  [_, sign, hrs, mins] <- sequence =<< RE.match re s
+  let readNum = map toNumber <<< fromString
+  hrs' <- readNum hrs
+  mins' <- readNum mins
+  let offset  = convertDuration (Hours hrs') + Minutes mins'
+  pure $ (if sign=="-" then negate else id) offset
 
 toDateTime :: RFC3339String -> Maybe DateTime
 toDateTime = JSDate.toDateTime <<< unsafeParse <<< unwrap

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -56,8 +56,8 @@ toLocale (RFC3339String s) = Locale Nothing $ fromMaybe zero $ unsafePartial $ d
   let readNum = map toNumber <<< fromString
   hrs' <- readNum hrs
   mins' <- readNum mins
-  let offset  = convertDuration (Hours hrs') + Minutes mins'
-  pure $ (if sign=="-" then negate else id) offset
+  let offset = convertDuration (Hours hrs') + Minutes mins'
+  pure $ (if sign == "-" then negate else id) offset
 
 toDateTime :: RFC3339String -> Maybe DateTime
 toDateTime = JSDate.toDateTime <<< unsafeParse <<< unwrap

--- a/src/Data/RFC3339String/Format.purs
+++ b/src/Data/RFC3339String/Format.purs
@@ -19,7 +19,7 @@ iso8601Format = dateTimeFormatISO <> fromFoldable
   ]
 
 -- Assumes the locale is valid, i.e. the offset is between
--- [-720, +720] minutes.
+-- [-1440, +1440] minutes.
 formatLocale :: Locale -> String
 formatLocale (Locale _ (Minutes mins))
   | mins == zero = "Z"

--- a/src/Data/RFC3339String/Format.purs
+++ b/src/Data/RFC3339String/Format.purs
@@ -23,7 +23,7 @@ iso8601Format = dateTimeFormatISO <> fromFoldable
 formatLocale :: Locale -> String
 formatLocale (Locale _ (Minutes mins))
   | mins == zero = "Z"
-  | otherwise = s <> padShow (m `div` 60) <> padShow (m `mod` 60)
+  | otherwise = s <> padShow (m `div` 60) <>":" <> padShow (m `mod` 60)
   where
     padShow n = takeRight 2 $ "00" <> show n
     s | mins >= zero = "+"

--- a/src/Data/RFC3339String/Format.purs
+++ b/src/Data/RFC3339String/Format.purs
@@ -23,7 +23,7 @@ iso8601Format = dateTimeFormatISO <> fromFoldable
 formatLocale :: Locale -> String
 formatLocale (Locale _ (Minutes mins))
   | mins == zero = "Z"
-  | otherwise = s <> padShow (m `div` 60) <>":" <> padShow (m `mod` 60)
+  | otherwise = s <> padShow (m `div` 60) <> ":" <> padShow (m `mod` 60)
   where
     padShow n = takeRight 2 $ "00" <> show n
     s | mins >= zero = "+"

--- a/src/Data/RFC3339String/Format.purs
+++ b/src/Data/RFC3339String/Format.purs
@@ -2,9 +2,14 @@ module Data.RFC3339String.Format where
 
 import Prelude
 
-import Data.Formatter.DateTime (FormatterCommand(..))
+import Data.DateTime.Locale (Locale(..))
+import Data.Formatter.DateTime (FormatterCommand(Placeholder, Milliseconds))
+import Data.Int (floor)
 import Data.List (List, fromFoldable)
 import Data.PreciseDateTime.Internal (dateTimeFormatISO)
+import Data.String (takeRight)
+import Data.Time.Duration (Minutes(..))
+import Math (abs)
 
 iso8601Format :: List FormatterCommand
 iso8601Format = dateTimeFormatISO <> fromFoldable
@@ -12,3 +17,15 @@ iso8601Format = dateTimeFormatISO <> fromFoldable
   , Milliseconds
   , Placeholder "Z"
   ]
+
+-- Assumes the locale is valid, i.e. the offset is between
+-- [-720, +720] minutes.
+formatLocale :: Locale -> String
+formatLocale (Locale _ (Minutes mins))
+  | mins == zero = "Z"
+  | otherwise = s <> padShow (m `div` 60) <> padShow (m `mod` 60)
+  where
+    padShow n = takeRight 2 $ "00" <> show n
+    s | mins >= zero = "+"
+      | otherwise    = "-"
+    m = floor <<< abs $ mins

--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -31,14 +31,14 @@ toString :: PreciseDuration -> String
 toString =
   let s = show <<< toNumber
   in case _ of
-    Nanoseconds d -> s d  <> "ns"
-    Microseconds d ->  s d  <> "us"
-    Milliseconds d ->  s d  <> "ms"
-    Seconds d ->  s d  <> "s"
-    Minutes d ->  s d  <> "m"
-    Hours d ->  s d  <> "h"
-    Days d ->  s d  <> "d"
-    Weeks d ->  s d  <> "w"
+    Nanoseconds d -> s d <> "ns"
+    Microseconds d -> s d <> "us"
+    Milliseconds d -> s d <> "ms"
+    Seconds d -> s d <> "s"
+    Minutes d -> s d <> "m"
+    Hours d -> s d <> "h"
+    Days d -> s d <> "d"
+    Weeks d -> s d <> "w"
 
 unPreciseDuration :: PreciseDuration -> BigInt
 unPreciseDuration = case _ of

--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -2,7 +2,7 @@ module Data.Time.PreciseDuration where
 
 import Prelude
 
-import Data.BigInt (BigInt, fromInt)
+import Data.BigInt (BigInt, fromInt, toNumber)
 
 data PreciseDuration
   = Nanoseconds BigInt
@@ -26,6 +26,19 @@ instance showPreciseDuration :: Show PreciseDuration where
   show (Hours d) = "(Hours " <> show d <> ")"
   show (Days d) = "(Days " <> show d <> ")"
   show (Weeks d) = "(Weeks " <> show d <> ")"
+
+toString :: PreciseDuration -> String
+toString =
+  let s = show <<< toNumber
+  in case _ of
+    Nanoseconds d -> s d  <> "ns"
+    Microseconds d ->  s d  <> "us"
+    Milliseconds d ->  s d  <> "ms"
+    Seconds d ->  s d  <> "s"
+    Minutes d ->  s d  <> "m"
+    Hours d ->  s d  <> "h"
+    Days d ->  s d  <> "d"
+    Weeks d ->  s d  <> "w"
 
 unPreciseDuration :: PreciseDuration -> BigInt
 unPreciseDuration = case _ of

--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -2,7 +2,8 @@ module Data.Time.PreciseDuration where
 
 import Prelude
 
-import Data.BigInt (BigInt, fromInt, toNumber)
+import Data.BigInt (BigInt)
+import Data.BigInt as BigInt
 
 data PreciseDuration
   = Nanoseconds BigInt
@@ -29,16 +30,15 @@ instance showPreciseDuration :: Show PreciseDuration where
 
 toString :: PreciseDuration -> String
 toString =
-  let s = show <<< toNumber
-  in case _ of
-    Nanoseconds d -> s d <> "ns"
-    Microseconds d -> s d <> "us"
-    Milliseconds d -> s d <> "ms"
-    Seconds d -> s d <> "s"
-    Minutes d -> s d <> "m"
-    Hours d -> s d <> "h"
-    Days d -> s d <> "d"
-    Weeks d -> s d <> "w"
+  case _ of
+    Nanoseconds d -> BigInt.toString d <> "ns"
+    Microseconds d -> BigInt.toString d <> "us"
+    Milliseconds d -> BigInt.toString d <> "ms"
+    Seconds d -> BigInt.toString d <> "s"
+    Minutes d -> BigInt.toString d <> "m"
+    Hours d -> BigInt.toString d <> "h"
+    Days d -> BigInt.toString d <> "d"
+    Weeks d -> BigInt.toString d <> "w"
 
 unPreciseDuration :: PreciseDuration -> BigInt
 unPreciseDuration = case _ of
@@ -52,14 +52,14 @@ unPreciseDuration = case _ of
   Weeks d -> d
 
 -- Each duration in nanoseconds
-nano = fromInt 1 :: BigInt
-micro = (nano * fromInt 1000) :: BigInt
-milli = (micro * fromInt 1000) :: BigInt
-second = (milli * fromInt 1000) :: BigInt
-minute = (second * fromInt 60) :: BigInt
-hour = (minute * fromInt 60) :: BigInt
-day = (hour * fromInt 24) :: BigInt
-week = (day * fromInt 7) :: BigInt
+nano = BigInt.fromInt 1 :: BigInt
+micro = (nano * BigInt.fromInt 1000) :: BigInt
+milli = (micro * BigInt.fromInt 1000) :: BigInt
+second = (milli * BigInt.fromInt 1000) :: BigInt
+minute = (second * BigInt.fromInt 60) :: BigInt
+hour = (minute * BigInt.fromInt 60) :: BigInt
+day = (hour * BigInt.fromInt 24) :: BigInt
+week = (day * BigInt.fromInt 7) :: BigInt
 
 toNanoseconds' :: PreciseDuration -> BigInt
 toNanoseconds' duration = case duration of

--- a/test/Data/PreciseDateTime.purs
+++ b/test/Data/PreciseDateTime.purs
@@ -238,6 +238,9 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 123 123456789)
 
     it "locale" do
+      -- NB: these tests do not ensure that the locale is actually correct
+      -- because the fromRFC3339String function always sets it as 0.
+
       -- NB: The "+/- time" specifies that the timezone the date is in.
       -- The datetime object will be normalized to GMT, so "x+0800" in GMT is x
       -- but 8 hours behind.

--- a/test/Data/PreciseDateTime/Locale.purs
+++ b/test/Data/PreciseDateTime/Locale.purs
@@ -7,7 +7,7 @@ import Data.DateTime.Locale (LocalValue(..), Locale(..))
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
 import Data.PreciseDateTime as PDT
-import Data.PreciseDateTime.Locale (fromRFC3339String)
+import Data.PreciseDateTime.Locale (fromRFC3339String, toRFC3339String)
 import Data.RFC3339String (RFC3339String(..))
 import Data.Time.Duration as Dur
 import Data.Time.PreciseDuration (PreciseDuration(..))
@@ -15,14 +15,16 @@ import Test.Data.PreciseDateTime.Spec (dateStringFixture, preciseDateTimeFixture
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
+withTZ hrsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Hours (toNumber hrsTZ)))))
+               <<< PDT.adjust (Hours (fromInt (negate hrsTZ)))
+
+withTZMins minsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Minutes (toNumber minsTZ)))))
+               <<< PDT.adjust (Minutes (fromInt (negate minsTZ)))
+
 spec :: forall r. Spec r Unit
 spec =
   describe "LocalPreciseDateTime" do
     it "fromRFC3339String" do
-      let withTZ hrsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Hours (toNumber hrsTZ)))))
-                         <<< PDT.adjust (Hours (fromInt (negate hrsTZ)))
-      let withTZMins minsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Minutes (toNumber minsTZ)))))
-                         <<< PDT.adjust (Minutes (fromInt (negate minsTZ)))
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> "+08:00")
         `shouldEqual` withTZ 8 (preciseDateTimeFixture 0 0)
@@ -41,3 +43,10 @@ spec =
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> "-00:01")
         `shouldEqual` withTZMins (-1) (preciseDateTimeFixture 0 0)
+
+    it "toRFC3339String" do
+      toRFC3339String (LocalValue (Locale Nothing zero) (preciseDateTimeFixture 0 0))
+        `shouldEqual` RFC3339String (dateStringFixture <>"Z")
+
+      toRFC3339String (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Hours 4.0))) (preciseDateTimeFixture 0 0))
+        `shouldEqual` RFC3339String (dateStringFixture <>"+04:00")

--- a/test/Data/PreciseDateTime/Locale.purs
+++ b/test/Data/PreciseDateTime/Locale.purs
@@ -1,0 +1,29 @@
+module Test.Data.PreciseDateTime.Locale.Spec where
+
+import Prelude
+
+import Data.BigInt (fromInt)
+import Data.DateTime.Locale (LocalValue(..), Locale(..))
+import Data.Int (toNumber)
+import Data.Maybe (Maybe(..))
+import Data.PreciseDateTime as PDT
+import Data.PreciseDateTime.Locale (fromRFC3339String)
+import Data.RFC3339String (RFC3339String(..))
+import Data.Time.Duration as Dur
+import Data.Time.PreciseDuration (PreciseDuration(..))
+import Test.Data.PreciseDateTime.Spec (dateStringFixture, preciseDateTimeFixture)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: forall r. Spec r Unit
+spec =
+  describe "LocalPreciseDateTime" do
+    it "locale" do
+      let withTZ hrsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Hours (toNumber hrsTZ)))))
+                         <<< PDT.adjust (Hours (fromInt (negate hrsTZ)))
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "+08:00")
+        `shouldEqual` withTZ 8 (preciseDateTimeFixture 0 0)
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "-08:00")
+        `shouldEqual` withTZ (-8) (preciseDateTimeFixture 0 0)

--- a/test/Data/PreciseDateTime/Locale.purs
+++ b/test/Data/PreciseDateTime/Locale.purs
@@ -18,12 +18,26 @@ import Test.Spec.Assertions (shouldEqual)
 spec :: forall r. Spec r Unit
 spec =
   describe "LocalPreciseDateTime" do
-    it "locale" do
+    it "fromRFC3339String" do
       let withTZ hrsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Hours (toNumber hrsTZ)))))
                          <<< PDT.adjust (Hours (fromInt (negate hrsTZ)))
+      let withTZMins minsTZ = map (LocalValue (Locale Nothing (Dur.convertDuration (Dur.Minutes (toNumber minsTZ)))))
+                         <<< PDT.adjust (Minutes (fromInt (negate minsTZ)))
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> "+08:00")
         `shouldEqual` withTZ 8 (preciseDateTimeFixture 0 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> "-08:00")
         `shouldEqual` withTZ (-8) (preciseDateTimeFixture 0 0)
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "Z")
+        `shouldEqual` withTZ 0 (preciseDateTimeFixture 0 0)
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "-00:00")
+        `shouldEqual` withTZ 0 (preciseDateTimeFixture 0 0)
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "+00:00")
+        `shouldEqual` withTZ 0 (preciseDateTimeFixture 0 0)
+
+      fromRFC3339String (RFC3339String $ dateStringFixture <> "-00:01")
+        `shouldEqual` withTZMins (-1) (preciseDateTimeFixture 0 0)


### PR DESCRIPTION
Adds a type alias, `type LocalPreciseDateTime = LocalValue PreciseDateTime`, akin to `LocalDateTime` in `Data.DateTime.Locale`.