### PR TITLE
Make Nanosecond represent time < 1 Millisecond

### DIFF
--- a/src/Data/PreciseDate/Component.purs
+++ b/src/Data/PreciseDate/Component.purs
@@ -8,10 +8,13 @@ import Data.Enum (class BoundedEnum, class Enum, Cardinality(..), fromEnum, toEn
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 
--- | An nanosecond component for a time value.
+-- | A nanosecond component for a time value.
+-- |
+-- | Must be used in conjunction with a millisecond component to represent the
+-- | total amount of time less than 1 second.
 -- |
 -- | The constructor is private as values for the type are restricted to the
--- | range 0 to 999999999, inclusive. The `toEnum` function can be used to
+-- | range 0 to 999999, inclusive. The `toEnum` function can be used to
 -- | safely acquire an `Nanosecond` value from an integer. Correspondingly, a
 -- | `Nanosecond` can be lowered to a plain integer with the `fromEnum`
 -- | function.
@@ -23,16 +26,16 @@ derive newtype instance ordNanosecond :: Ord Nanosecond
 
 instance boundedNanosecond :: Bounded Nanosecond where
   bottom = Nanosecond 0
-  top = Nanosecond 999999999
+  top = Nanosecond 999999
 
 instance enumNanosecond :: Enum Nanosecond where
   succ = toEnum <<< (_ + 1) <<< fromEnum
   pred = toEnum <<< (_ - 1) <<< fromEnum
 
 instance boundedEnumNanosecond :: BoundedEnum Nanosecond where
-  cardinality = Cardinality 1000000000
+  cardinality = Cardinality 1000000
   toEnum n
-    | n >= 0 && n <= 999999999 = Just (Nanosecond n)
+    | n >= 0 && n <= 999999 = Just (Nanosecond n)
     | otherwise = Nothing
   fromEnum (Nanosecond n) = n
 

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -12,11 +12,11 @@ import Prelude
 import Control.Alt ((<|>))
 import Data.Array ((!!))
 import Data.Char.Unicode (isDigit)
-import Data.DateTime (DateTime)
+import Data.DateTime (DateTime, millisecond, time)
 import Data.DateTime as DateTime
-import Data.Decimal (Decimal, pow, modulo, truncated)
+import Data.Decimal (Decimal, pow, truncated)
 import Data.Decimal as Decimal
-import Data.Enum (toEnum)
+import Data.Enum (fromEnum, toEnum)
 import Data.Formatter.DateTime (format)
 import Data.Int (decimal)
 import Data.Int as Int
@@ -26,7 +26,7 @@ import Data.PreciseDate.Component (Nanosecond)
 import Data.PreciseDateTime.Internal (dateTimeFormatISO)
 import Data.RFC3339String (RFC3339String(..), trim)
 import Data.RFC3339String as RFC3339String
-import Data.String (Pattern(Pattern), drop, length, split, takeWhile)
+import Data.String (Pattern(Pattern), drop, length, split, take, takeWhile)
 import Data.Time.Duration as Duration
 import Data.Time.PreciseDuration (PreciseDuration(..), toMilliseconds, toNanoseconds, unPreciseDuration)
 
@@ -42,12 +42,29 @@ instance boundedPreciseDateTime :: Bounded PreciseDateTime where
 instance showPreciseDateTime :: Show PreciseDateTime where
   show (PreciseDateTime dateTime ns) = "PreciseDateTime (" <> show dateTime <> ") " <> show ns
 
-nanoStringPadding = "000000000" :: String
+milliStringPadding = "000" :: String
+nanoStringPadding = "000000" :: String
+subsecondStringPadding = "000000000" :: String
+
+padString :: String -> (String -> String -> String) -> String -> String
+padString p fn string =
+  let padding = drop (length string) p
+  in fn string padding
+
+padMilliString :: (String -> String -> String) -> String -> String
+padMilliString = padString milliStringPadding
 
 padNanoString :: (String -> String -> String) -> String -> String
-padNanoString fn string =
-  let padding = drop (length string) nanoStringPadding
-  in fn string padding
+padNanoString = padString nanoStringPadding
+
+padSubsecondString :: (String -> String -> String) -> String -> String
+padSubsecondString = padString subsecondStringPadding
+
+leftPadMilliString :: String -> String
+leftPadMilliString = padMilliString (flip append)
+
+rightPadMilliString :: String -> String
+rightPadMilliString = padMilliString append
 
 leftPadNanoString :: String -> String
 leftPadNanoString = padNanoString (flip append)
@@ -55,19 +72,27 @@ leftPadNanoString = padNanoString (flip append)
 rightPadNanoString :: String -> String
 rightPadNanoString = padNanoString append
 
-parseSubseconds :: RFC3339String -> Maybe Int
+leftPadSubsecondString :: String -> String
+leftPadSubsecondString = padSubsecondString (flip append)
+
+rightPadSubsecondString :: String -> String
+rightPadSubsecondString = padSubsecondString append
+
+parseSubseconds :: RFC3339String -> Maybe String
 parseSubseconds (RFC3339String s) = do
   let parts = split (Pattern ".") s
   afterDot <- parts !! 1
   let digits = takeWhile isDigit afterDot
-  Int.fromString <<< rightPadNanoString $ digits
+  pure $ rightPadSubsecondString $ take 9 digits
 
 -- | Convert to `Nanosecond` separately so that a failure to parse subseconds
 -- | results in `Just (Nanosecond 0)` instead of `Nothing`. This accounts for
 -- | when subseconds were omitted from the timestamp, and allows us to
 -- | differentiate between invalid `Int`s and invalid `Nanosecond`s.
 nanosecond :: RFC3339String -> Maybe Nanosecond
-nanosecond rfcString = parseSubseconds rfcString <|> Just 0 >>= toEnum
+nanosecond rfcString = nanoseconds rfcString <|> Just 0 >>= toEnum
+  where
+  nanoseconds = parseSubseconds >=> drop 3 >>> Int.fromString
 
 fromRFC3339String :: RFC3339String -> Maybe PreciseDateTime
 fromRFC3339String rfcString = do
@@ -79,10 +104,12 @@ toRFC3339String :: PreciseDateTime -> RFC3339String
 toRFC3339String (PreciseDateTime dateTime ns) =
   let
     beforeDot = format dateTimeFormatISO dateTime
-    nanos = Int.toStringAs decimal (unwrap ns)
-    leftPadded = leftPadNanoString nanos
+    millis = Int.toStringAs decimal $ fromEnum $ millisecond $ time dateTime
+    nanos = Int.toStringAs decimal $ unwrap ns
+    leftPaddedMs = leftPadMilliString millis
+    leftPaddedNs = leftPadNanoString nanos
   in
-    trim <<< RFC3339String $ beforeDot <> "." <> leftPadded <> "Z"
+    trim <<< RFC3339String $ beforeDot <> "." <> leftPaddedMs <> leftPaddedNs <> "Z"
 
 -- | Adjusts a date/time value with a duration offset. `Nothing` is returned
 -- | if the resulting date would be outside of the range of valid dates.
@@ -97,15 +124,13 @@ adjust pd (PreciseDateTime dt ns) = do
     roundTripDurInt = unPreciseDuration <<< toNanoseconds $ Milliseconds msPrecDurDec
 
     negative = nsPrecDurInt < zero
-    msModTen = msPrecDurDec `modulo` ten
     nsDiff = nsPrecDurInt - roundTripDurInt
 
-    -- If the duration is negative, the duration in milliseconds is a multiple
-    -- of 10, and the conversion from nanoseconds to milliseconds and back is
-    -- not lossless, then we need to round up the lost nanoseconds to 1
-    -- millisecond and adjust the duration.
+    -- If the duration is negative and the conversion from nanoseconds to
+    -- milliseconds and back is not lossless then we need to round up the lost
+    -- nanoseconds to 1 millisecond and adjust the duration.
     adjustment =
-      if negative && msModTen == zero && nsDiff < zero
+      if negative && nsDiff < zero
          then 1
          else 0
 
@@ -117,23 +142,23 @@ adjust pd (PreciseDateTime dt ns) = do
   adjustedDateTime <- DateTime.adjust msDur dt
 
   -- If the duration is larger than can be represented in a `Nanosecond`
-  -- component, take the last 9 digits.
+  -- component, take the last 6 digits.
   let
     unsigned = Decimal.abs nsPrecDurInt
     nsString = Decimal.toString unsigned
 
-    lastNine =
+    lastSix =
       if unsigned > maxNano
-        then drop (length nsString - 9) nsString
+        then drop (length nsString - 6) nsString
         else nsString
 
-  adjustedNsPrecDurInt <- Decimal.fromString lastNine
+  adjustedNsPrecDurInt <- Decimal.fromString lastSix
   let adjustedNsInt = Decimal.fromInt (unwrap ns) + adjustedNsPrecDurInt
 
   let
     inverted =
       if negative && adjustedNsInt <= maxNano && adjustedNsPrecDurInt /= zero
-         then tenPowNine - adjustedNsInt
+         then tenPowSix - adjustedNsInt
          else adjustedNsInt
 
   adjustedNs <- toInt inverted >>= toEnum
@@ -142,9 +167,8 @@ adjust pd (PreciseDateTime dt ns) = do
   where
     zero = Decimal.fromInt 0
     ten = Decimal.fromInt 10
-    tenPowNine = ten `pow` Decimal.fromInt 9
-    maxNano = tenPowNine - Decimal.fromInt 1
-    maxm = ten `pow` Decimal.fromInt 22
+    tenPowSix = ten `pow` Decimal.fromInt 6
+    maxNano = tenPowSix - Decimal.fromInt 1
 
     -- | Coerce a `Data.Decimal` to an Int, preserving precision.
     toInt :: Decimal -> Maybe Int

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -47,9 +47,7 @@ nanoStringPadding = "000000" :: String
 subsecondStringPadding = "000000000" :: String
 
 padString :: String -> (String -> String -> String) -> String -> String
-padString p fn string =
-  let padding = drop (length string) p
-  in fn string padding
+padString padding fn string = fn string $ drop (length string) padding
 
 padMilliString :: (String -> String -> String) -> String -> String
 padMilliString = padString milliStringPadding

--- a/test/Data/PreciseDateTime.purs
+++ b/test/Data/PreciseDateTime.purs
@@ -47,40 +47,41 @@ spec =
         `shouldEqual` (Just $ preciseDateTimeFixture 0 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".1Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 100 100000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 100 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".01Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 10 10000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 10 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".001Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 1 1000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 1 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".10Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 100 100000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 100 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".100Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 100 100000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 100 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".123Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 123 123000000)
+        `shouldEqual` (Just $ preciseDateTimeFixture 123 0)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".999999999Z")
-        `shouldEqual` (Just $ preciseDateTimeFixture 999 999999999)
+        `shouldEqual` (Just $ preciseDateTimeFixture 999 999999)
 
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".000000001Z")
         `shouldEqual` (Just $ preciseDateTimeFixture 0 1)
 
+      -- Take the first 9 digits if more than 9 are provided
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".1000000000Z")
-        `shouldEqual` Nothing
+        `shouldEqual` (Just $ preciseDateTimeFixture 100 0)
 
-    it "toRFC3339String" do
+    it"toRFC3339String" do
       toRFC3339String (preciseDateTimeFixture 0 0)
         `shouldEqual` (RFC3339String $ dateStringFixture <> ".0Z")
 
-      toRFC3339String (preciseDateTimeFixture 123 123000000)
+      toRFC3339String (preciseDateTimeFixture 123 0)
         `shouldEqual` (RFC3339String $ dateStringFixture <> ".123Z")
 
-      toRFC3339String (preciseDateTimeFixture 999 999999999)
+      toRFC3339String (preciseDateTimeFixture 999 999999)
         `shouldEqual` (RFC3339String $ dateStringFixture <> ".999999999Z")
 
       toRFC3339String (preciseDateTimeFixture 0 1)
@@ -100,37 +101,37 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 0 1)
 
       adjust (Nanoseconds <<< fromInt $ -1) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 999 999999)
 
       adjust (Nanoseconds <<< fromInt $ 1000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 1 1000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 1 0)
 
       adjust(Nanoseconds <<< fromInt $ -1000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 999 999000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 999 0)
 
       adjust (Nanoseconds <<< fromInt $ 10000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 10 10000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 10 0)
 
       adjust (Nanoseconds <<< fromInt $ -10000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 990 990000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 990 0)
 
       adjust (Nanoseconds <<< fromInt $ 100000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 100 100000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 100 0)
 
       adjust (Nanoseconds <<< fromInt $ -100000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 900 900000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 900 0)
 
       adjust (Nanoseconds <<< fromInt $ 123456789) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 123 123456789)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 123 456789)
 
       adjust (Nanoseconds <<< fromInt $ -123456789) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 877 876543211)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 876 543211)
 
       adjust (Nanoseconds <<< fromInt $ 999999999) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 999 999999)
 
       adjust (Nanoseconds <<< fromInt $ -999999999) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 1 1)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 0 1)
 
       adjust (Nanoseconds <<< fromInt $ 1000000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 1 0 0)
@@ -142,37 +143,37 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 1 0 1)
 
       adjust (Nanoseconds <<< fromInt $ -1000000001) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999)
 
       adjust (Nanoseconds <<< fromInt $ -1000000002) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999998)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999998)
 
       adjust (Nanoseconds <<< fromInt $ 1000000010) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 1 0 10)
 
       adjust (Nanoseconds <<< fromInt $ -1000000010) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999990)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999990)
 
       adjust (Nanoseconds <<< fromInt $ 1000000100) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 1 0 100)
 
       adjust (Nanoseconds <<< fromInt $ -1000000100) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999900)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999900)
 
       adjust (Nanoseconds <<< fromInt $ -1000001000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999999000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999000)
 
       adjust (Nanoseconds <<< fromInt $ -1000010000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999990000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 990000)
 
       adjust (Nanoseconds <<< fromInt $ -1000100000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999900000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 900000)
 
       adjust (Nanoseconds <<< fromInt $ -1001000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 999000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 999 0)
 
       adjust (Nanoseconds <<< fromInt $ -1010000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 990 990000000)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 58 990 0)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-10000000000") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 50 0 0)
@@ -187,7 +188,7 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 1 0 0 1)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-60000000001") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 58 59 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 58 59 999 999999)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "3600000000000") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 1 0 0 0 0)
@@ -199,7 +200,7 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 1 0 0 0 1)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-3600000000001") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 22 59 59 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 22 59 59 999 999999)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "86400000000000") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 14 0 0 0 0 0)
@@ -211,7 +212,7 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 14 0 0 0 0 1)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-86400000000001") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 11 23 59 59 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 11 23 59 59 999 999999)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "604800000000000") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 20 0 0 0 0 0)
@@ -223,13 +224,13 @@ spec =
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 20 0 0 0 0 1)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-604800000000001") (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
-        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 5 23 59 59 999 999999999)
+        `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 5 23 59 59 999 999999)
 
       adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-300000000000") (mkPreciseDateTime 2017 Date.September 17 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 0 0)
 
-      adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-300000000000") (mkPreciseDateTime 2017 Date.September 17 0 0 0 123 123000000)
-        `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 123 123000000)
+      adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-300000000000") (mkPreciseDateTime 2017 Date.September 17 0 0 0 123 0)
+        `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 123 0)
 
-      adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-300000000000") (mkPreciseDateTime 2017 Date.September 17 0 0 0 123 123456789)
-        `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 123 123456789)
+      adjust (Nanoseconds <<< unsafePartial fromJust <<< fromString $ "-300000000000") (mkPreciseDateTime 2017 Date.September 17 0 0 0 123 456789)
+        `shouldEqual` (Just $ mkPreciseDateTime 2017 Date.September 16 23 55 0 123 456789)


### PR DESCRIPTION
I think that this should close #9, in that doing this means that we don't need smart constructors.