### PR TITLE
Use fixed-point notation in toString

### DIFF
--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -57,16 +57,19 @@ instance showPreciseDuration :: Show PreciseDuration where
   show (Days d) = "(Days " <> show d <> ")"
   show (Weeks d) = "(Weeks " <> show d <> ")"
 
+toFixed :: Decimal -> String
+toFixed = Decimal.toFixed 9
+
 toString :: PreciseDuration -> String
 toString = case _ of
-  Nanoseconds d -> Decimal.toString d <> "ns"
-  Microseconds d -> Decimal.toString d <> "us"
-  Milliseconds d -> Decimal.toString d <> "ms"
-  Seconds d -> Decimal.toString d <> "s"
-  Minutes d -> Decimal.toString d <> "m"
-  Hours d -> Decimal.toString d <> "h"
-  Days d -> Decimal.toString d <> "d"
-  Weeks d -> Decimal.toString d <> "w"
+  Nanoseconds d -> toFixed d <> "ns"
+  Microseconds d -> toFixed d <> "us"
+  Milliseconds d -> toFixed d <> "ms"
+  Seconds d -> toFixed d <> "s"
+  Minutes d -> toFixed d <> "m"
+  Hours d -> toFixed d <> "h"
+  Days d -> toFixed d <> "d"
+  Weeks d -> toFixed d <> "w"
 
 negatePreciseDuration :: PreciseDuration -> PreciseDuration
 negatePreciseDuration = case _ of


### PR DESCRIPTION
This fixes an issue where `toString $ toSeconds $ nanoseconds 1` would produce `"1e-9s"` instead of `"0.000000001s"`.

```
> Decimal.toString $ Decimal.fromNumber 0.000000001
"1e-9"

> Decimal.toFixed 9 $ Decimal.fromNumber 0.000000001
"0.000000001"
```