### PR TITLE
Don't use exponential notation in PreciseDuration toString

### DIFF
--- a/src/Data/PreciseDateTime/Internal.purs
+++ b/src/Data/PreciseDateTime/Internal.purs
@@ -2,8 +2,11 @@ module Data.PreciseDateTime.Internal where
 
 import Prelude
 
+import Data.Array as Array
 import Data.Formatter.DateTime (FormatterCommand(..))
 import Data.List (List, fromFoldable)
+import Data.String.CodeUnits as String
+import Data.Tuple (Tuple(..), snd)
 
 dateFormat :: List FormatterCommand
 dateFormat = fromFoldable
@@ -25,3 +28,11 @@ timeFormat = fromFoldable
 
 dateTimeFormatISO :: List FormatterCommand
 dateTimeFormatISO = dateFormat <> pure (Placeholder "T") <> timeFormat
+
+-- | Returns the prefix remaining after dropping characters that satisfy the
+-- | predicate from the end of the string.
+dropWhileEnd :: (Char -> Boolean) -> String -> String
+dropWhileEnd p s = snd $ Array.foldr check (Tuple false "") (String.toCharArray s)
+  where
+    check c state@(Tuple false _) = if p c then state else Tuple true (String.singleton c)
+    check c state@(Tuple true string) = Tuple true (String.singleton c <> string)

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -3,15 +3,13 @@ module Data.RFC3339String where
 import Prelude
 
 import Data.DateTime (DateTime)
-import Data.Foldable (foldr)
 import Data.Formatter.DateTime (format)
 import Data.JSDate (JSDate)
 import Data.JSDate as JSDate
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, unwrap)
+import Data.PreciseDateTime.Internal (dropWhileEnd)
 import Data.RFC3339String.Format (iso8601Format)
-import Data.String.CodeUnits as String
-import Data.Tuple (Tuple(..), snd)
 import Effect.Unsafe (unsafePerformEffect)
 
 newtype RFC3339String = RFC3339String String
@@ -50,11 +48,3 @@ toDateTime = JSDate.toDateTime <<< unsafeParse <<< unwrap
   -- | for why this is "unsafe".
   unsafeParse :: String -> JSDate
   unsafeParse = unsafePerformEffect <<< JSDate.parse
-
--- | Returns the prefix remaining after dropping characters that satisfy the
--- | predicate from the end of the string.
-dropWhileEnd :: (Char -> Boolean) -> String -> String
-dropWhileEnd p s = snd $ foldr check (Tuple false "") (String.toCharArray s)
-  where
-    check c state@(Tuple false _) = if p c then state else Tuple true (String.singleton c)
-    check c state@(Tuple true string) = Tuple true (String.singleton c <> string)

--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -28,6 +28,7 @@ import Prelude
 
 import Data.Decimal (Decimal)
 import Data.Decimal as Decimal
+import Data.PreciseDateTime.Internal (dropWhileEnd)
 
 data PreciseDuration
   = Nanoseconds Decimal
@@ -59,14 +60,22 @@ instance showPreciseDuration :: Show PreciseDuration where
 
 toString :: PreciseDuration -> String
 toString = case _ of
-  Nanoseconds d -> Decimal.toString d <> "ns"
-  Microseconds d -> Decimal.toString d <> "us"
-  Milliseconds d -> Decimal.toString d <> "ms"
-  Seconds d -> Decimal.toString d <> "s"
-  Minutes d -> Decimal.toString d <> "m"
-  Hours d -> Decimal.toString d <> "h"
-  Days d -> Decimal.toString d <> "d"
-  Weeks d -> Decimal.toString d <> "w"
+  Nanoseconds d -> format d <> "ns"
+  Microseconds d -> format d <> "us"
+  Milliseconds d -> format d <> "ms"
+  Seconds d -> format d <> "s"
+  Minutes d -> format d <> "m"
+  Hours d -> format d <> "h"
+  Days d -> format d <> "d"
+  Weeks d -> format d <> "w"
+
+  where
+
+  format :: Decimal -> String
+  format = trim <<< Decimal.toFixed 20
+
+  trim :: String -> String
+  trim = dropWhileEnd (_ == '.') <<< dropWhileEnd (_ == '0')
 
 negatePreciseDuration :: PreciseDuration -> PreciseDuration
 negatePreciseDuration = case _ of

--- a/test/Data/Time/PreciseDuration.purs
+++ b/test/Data/Time/PreciseDuration.purs
@@ -46,3 +46,13 @@ spec =
     it "toHours" $ test toHours PD.hours hour inputs
     it "toDays" $ test toDays PD.days day inputs
     it "toWeeks" $ test toWeeks PD.weeks week inputs
+
+    it "toString" do
+      PD.toString (PD.nanoseconds 1) `shouldEqual` "1ns"
+      PD.toString (PD.microseconds $ Decimal.fromNumber 1.0) `shouldEqual` "1us"
+      PD.toString (PD.milliseconds $ Decimal.fromNumber 1.0) `shouldEqual` "1ms"
+      PD.toString (PD.seconds $ Decimal.fromNumber 1.0) `shouldEqual` "1s"
+      PD.toString (PD.minutes $ Decimal.fromNumber 1.0) `shouldEqual` "1m"
+      PD.toString (PD.hours $ Decimal.fromNumber 1.0) `shouldEqual` "1h"
+      PD.toString (PD.days $ Decimal.fromNumber 1.0) `shouldEqual` "1d"
+      PD.toString (PD.weeks $ Decimal.fromNumber 1.0) `shouldEqual` "1w"

--- a/test/Data/Time/PreciseDuration.purs
+++ b/test/Data/Time/PreciseDuration.purs
@@ -56,3 +56,12 @@ spec =
       PD.toString (PD.hours $ Decimal.fromNumber 1.0) `shouldEqual` "1h"
       PD.toString (PD.days $ Decimal.fromNumber 1.0) `shouldEqual` "1d"
       PD.toString (PD.weeks $ Decimal.fromNumber 1.0) `shouldEqual` "1w"
+
+      -- Test that exponential notation is not used
+      PD.toString (PD.toMicroseconds $ PD.nanoseconds 1) `shouldEqual` "0.001us"
+      PD.toString (PD.toMilliseconds $ PD.nanoseconds 1) `shouldEqual` "0.000001ms"
+      PD.toString (PD.toSeconds $ PD.nanoseconds 1) `shouldEqual` "0.000000001s"
+      PD.toString (PD.toMinutes $ PD.nanoseconds 1) `shouldEqual` "0.00000000001666666667m"
+      PD.toString (PD.toHours $ PD.nanoseconds 1) `shouldEqual` "0.00000000000027777778h"
+      PD.toString (PD.toDays $ PD.nanoseconds 1) `shouldEqual`  "0.00000000000001157407d"
+      PD.toString (PD.toWeeks $ PD.nanoseconds 1) `shouldEqual` "0.00000000000000165344w"


### PR DESCRIPTION
I attempted something like this in https://github.com/awakesecurity/purescript-precise-datetime/pull/28 but reverted it with https://github.com/awakesecurity/purescript-precise-datetime/pull/29.

I'm converting to fixed-point notation again here but the difference is that I'm removing trailing zeros.

I used `dropWhileEnd` because it was already available but there are probably ways to make this more performant at some point in the future if that's a concern (e.g. regex). I don't want to address that right now.