### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 node_js: 10
 install:
   - npm install -g yarn
-  - yarn global add purescript@^0.12 pulp bower purescript-psa
+  - yarn global add purescript@^0.14 pulp bower purescript-psa
   - export PATH="$PATH:`yarn global bin`"
   - bower install
   - yarn install

--- a/bower.json
+++ b/bower.json
@@ -12,28 +12,28 @@
     "output"
   ],
   "dependencies": {
-    "purescript-arrays": "^5.0.0",
-    "purescript-console": "^4.1.0",
-    "purescript-datetime": "^4.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-enums": "^4.0.0",
-    "purescript-foldable-traversable": "^4.0.0",
-    "purescript-formatters": "^4.0.0",
-    "purescript-integers": "^4.0.0",
-    "purescript-js-date": "^6.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-maybe": "^4.0.0",
-    "purescript-newtype": "^3.0.0",
-    "purescript-prelude": "^4.0.1",
-    "purescript-strings": "^4.0.0",
-    "purescript-tuples": "^5.0.0",
-    "purescript-unicode": "^4.0.0",
-    "purescript-numbers": "^6.0.0",
-    "purescript-decimals": "^4.0.0"
+    "purescript-arrays": "^6.0.0",
+    "purescript-console": "^5.0.0",
+    "purescript-datetime": "^5.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-enums": "^5.0.0",
+    "purescript-foldable-traversable": "^5.0.0",
+    "purescript-formatters": "^5.0.0",
+    "purescript-integers": "^5.0.0",
+    "purescript-js-date": "^7.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-maybe": "^5.0.0",
+    "purescript-newtype": "^4.0.0",
+    "purescript-prelude": "^5.0.0",
+    "purescript-strings": "^5.0.0",
+    "purescript-tuples": "^6.0.0",
+    "purescript-unicode": "^5.0.0",
+    "purescript-numbers": "^8.0.0",
+    "purescript-decimals": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^4.0.0",
-    "purescript-spec": "^3.0.0",
-    "purescript-spec-discovery": "owickstrom/purescript-spec-discovery#06d37dbdb2f456a95b68543cc8a0371dbebf87b5"
+    "purescript-psci-support": "^5.0.0",
+    "purescript-spec": "^5.0.0",
+    "purescript-spec-discovery": "^6.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-tuples": "^6.0.0",
     "purescript-unicode": "^5.0.0",
     "purescript-numbers": "^8.0.0",
-    "purescript-decimals": "^5.0.0"
+    "purescript-decimals": "thomashoneyman/purescript-decimals#master"
   },
   "devDependencies": {
     "purescript-psci-support": "^5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/awakesecurity/purescript-precise-datetime.git"
+    "url": "https://github.com/awakesecurity/purescript-precise-datetime.git"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-tuples": "^6.0.0",
     "purescript-unicode": "^5.0.0",
     "purescript-numbers": "^8.0.0",
-    "purescript-decimals": "thomashoneyman/purescript-decimals#master"
+    "purescript-decimals": "^6.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^5.0.0",

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -12,7 +12,7 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Data.Array ((!!))
-import Data.Char.Unicode (isDigit)
+import Data.CodePoint.Unicode (isDecDigit)
 import Data.DateTime (DateTime, millisecond, time)
 import Data.DateTime as DateTime
 import Data.Decimal (Decimal, pow, truncated)
@@ -27,7 +27,7 @@ import Data.PreciseDate.Component (Nanosecond(..))
 import Data.PreciseDateTime.Internal (dateTimeFormatISO)
 import Data.RFC3339String (RFC3339String(..), trim)
 import Data.RFC3339String as RFC3339String
-import Data.String (Pattern(..), split)
+import Data.String (Pattern(..), codePointFromChar, split)
 import Data.String.CodeUnits (drop, length, take, takeWhile)
 import Data.Time.Duration as Duration
 import Data.Time.PreciseDuration (PreciseDuration, toDecimalLossy, toMilliseconds, toNanoseconds)
@@ -83,7 +83,7 @@ parseSubseconds :: RFC3339String -> Maybe String
 parseSubseconds (RFC3339String s) = do
   let parts = split (Pattern ".") s
   afterDot <- parts !! 1
-  let digits = takeWhile isDigit afterDot
+  let digits = takeWhile (isDecDigit <<< codePointFromChar) afterDot
   pure $ rightPadSubsecondString $ take 9 digits
 
 -- | Convert to `Nanosecond` separately so that a failure to parse subseconds

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,10 +1,14 @@
 module Test.Main where
 
 import Prelude
+
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.Spec.Discovery (discover)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = discover "Test\\..*\\.Spec" >>= run [consoleReporter]
+main = launchAff_ do
+  spec <- discover "Test\\..*\\.Spec"
+  runSpec [consoleReporter] spec


### PR DESCRIPTION
This PR updates the library for PureScript 0.14. It temporarily points at my fork of `decimals` until https://github.com/sharkdp/purescript-decimals/pull/11 is merged and there's a new release.