### PR TITLE
Upgrade to PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npm install purescript@^0.14 pulp bower purescript-psa
+          npm install purescript@^0.15 pulp bower purescript-psa
           npx bower install
 
       - name: Run tests

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/bower.json
+++ b/bower.json
@@ -12,28 +12,29 @@
     "output"
   ],
   "dependencies": {
-    "purescript-arrays": "^6.0.0",
-    "purescript-console": "^5.0.0",
-    "purescript-datetime": "^5.0.0",
-    "purescript-either": "^5.0.0",
-    "purescript-enums": "^5.0.0",
-    "purescript-foldable-traversable": "^5.0.0",
-    "purescript-formatters": "^5.0.0",
-    "purescript-integers": "^5.0.0",
-    "purescript-js-date": "^7.0.0",
-    "purescript-lists": "^6.0.0",
-    "purescript-maybe": "^5.0.0",
-    "purescript-newtype": "^4.0.0",
-    "purescript-prelude": "^5.0.0",
-    "purescript-strings": "^5.0.0",
-    "purescript-tuples": "^6.0.0",
-    "purescript-unicode": "^5.0.0",
-    "purescript-numbers": "^8.0.0",
-    "purescript-decimals": "^6.0.0"
+    "purescript-arrays": "^7.0.0",
+    "purescript-console": "^6.0.0",
+    "purescript-datetime": "^6.0.0",
+    "purescript-either": "^6.0.0",
+    "purescript-enums": "^6.0.0",
+    "purescript-foldable-traversable": "^6.0.0",
+    "purescript-formatters": "^7.0.0",
+    "purescript-integers": "^6.0.0",
+    "purescript-js-date": "^8.0.0",
+    "purescript-lists": "^7.0.0",
+    "purescript-maybe": "^6.0.0",
+    "purescript-newtype": "^5.0.0",
+    "purescript-prelude": "^6.0.0",
+    "purescript-strings": "^6.0.0",
+    "purescript-tuples": "^7.0.0",
+    "purescript-unicode": "^6.0.0",
+    "purescript-numbers": "^9.0.0",
+    "purescript-decimals": "^7.0.0",
+    "purescript-aff-promise": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^5.0.0",
-    "purescript-spec": "^5.0.0",
-    "purescript-spec-discovery": "^6.0.0"
+    "purescript-psci-support": "^6.0.0",
+    "purescript-spec": "^7.0.0",
+    "purescript-spec-discovery": "^8.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "devDependencies": {
         "big-integer": "^1.6.51",
-        "decimal.js": "^10.3.1"
+        "decimal.js": "^10.3.1",
+        "purs-tidy": "^0.8.0"
       }
     },
     "node_modules/big-integer": {
@@ -23,6 +24,15 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
+    },
+    "node_modules/purs-tidy": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.8.0.tgz",
+      "integrity": "sha512-eINM7qRodjV/2Ga6fpz2psLm7oGY+ILIm8G16A68J+AzG2VGpks3VZelho/4Ns0UV+czu5HvkrqesF5X9WeCxw==",
+      "dev": true,
+      "bin": {
+        "purs-tidy": "bin/index.js"
+      }
     }
   },
   "dependencies": {
@@ -36,6 +46,12 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "dev": true
+    },
+    "purs-tidy": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.8.0.tgz",
+      "integrity": "sha512-eINM7qRodjV/2Ga6fpz2psLm7oGY+ILIm8G16A68J+AzG2VGpks3VZelho/4Ns0UV+czu5HvkrqesF5X9WeCxw==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,41 @@
 {
+  "name": "purescript-precise-datetime",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "big-integer": "^1.6.51",
+        "decimal.js": "^10.3.1"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "dev": true
     },
     "decimal.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-9.0.1.tgz",
-      "integrity": "sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "big-integer": "^1.6.51",
-    "decimal.js": "^10.3.1"
+    "decimal.js": "^10.3.1",
+    "purs-tidy": "^0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "big-integer": "^1.6.26",
-    "decimal.js": "^9.0.1"
+    "big-integer": "^1.6.51",
+    "decimal.js": "^10.3.1"
   }
 }

--- a/src/Data/PreciseDateTime.purs
+++ b/src/Data/PreciseDateTime.purs
@@ -15,7 +15,6 @@ import Data.Array ((!!))
 import Data.CodePoint.Unicode (isDecDigit)
 import Data.DateTime (DateTime, millisecond, time)
 import Data.DateTime as DateTime
-import Data.Decimal (Decimal)
 import Data.Decimal as Decimal
 import Data.Enum (fromEnum, toEnum)
 import Data.Formatter.DateTime (format)
@@ -125,14 +124,11 @@ adjust pd (PreciseDateTime dt (Nanosecond ns)) = do
   flip PreciseDateTime (Nanosecond nanos)
     <$> DateTime.adjust (Milliseconds millis) dt
 
--- | Coerce a `Data.Decimal` to an Int, truncating it if it is out of range
-decimalToInt :: Decimal -> Int
-decimalToInt = Int.floor <<< Decimal.toNumber <<< Decimal.truncated
-
 diff :: PreciseDateTime -> PreciseDateTime -> PreciseDuration
 diff (PreciseDateTime dt0 (Nanosecond ns0)) (PreciseDateTime dt1 (Nanosecond ns1)) =
-  let Duration.Milliseconds msNum = DateTime.diff dt0 dt1
-      nsNum = Int.toNumber (ns0 - ns1) + msNum * 1000000.0
+  let
+    Duration.Milliseconds msNum = DateTime.diff dt0 dt1
+    nsNum = Int.toNumber (ns0 - ns1) + msNum * 1000000.0
   in
     PD.unsafeNanoseconds (Decimal.fromNumber nsNum)
 

--- a/src/Data/PreciseDateTime/Internal.purs
+++ b/src/Data/PreciseDateTime/Internal.purs
@@ -34,5 +34,5 @@ dateTimeFormatISO = dateFormat <> pure (Placeholder "T") <> timeFormat
 dropWhileEnd :: (Char -> Boolean) -> String -> String
 dropWhileEnd p s = snd $ Array.foldr check (Tuple false "") (String.toCharArray s)
   where
-    check c state@(Tuple false _) = if p c then state else Tuple true (String.singleton c)
-    check c (Tuple true string) = Tuple true (String.singleton c <> string)
+  check c state@(Tuple false _) = if p c then state else Tuple true (String.singleton c)
+  check c (Tuple true string) = Tuple true (String.singleton c <> string)

--- a/src/Data/RFC3339String.purs
+++ b/src/Data/RFC3339String.purs
@@ -29,9 +29,8 @@ trim (RFC3339String s) =
     withoutTrailingZeros = dropWhileEnd (eq '0') withoutZulu
     withoutTrailingDot = dropWhileEnd (eq '.') withoutTrailingZeros
   in
-    if withoutTrailingZeros == withoutTrailingDot
-    then RFC3339String $ withoutTrailingDot <> "Z"
-         -- always have a subseconds component
+    if withoutTrailingZeros == withoutTrailingDot then RFC3339String $ withoutTrailingDot <> "Z"
+    -- always have a subseconds component
     else RFC3339String $ withoutTrailingDot <> ".0Z"
 
 -- | Use our own formatter since we'd otherwise need to convert from `DateTime`

--- a/src/Data/Time/PreciseDuration.purs
+++ b/src/Data/Time/PreciseDuration.purs
@@ -2,7 +2,14 @@ module Data.Time.PreciseDuration
   ( PreciseDuration
   , toString
   , negatePreciseDuration
-  , nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days, weeks
+  , nanoseconds
+  , microseconds
+  , milliseconds
+  , seconds
+  , minutes
+  , hours
+  , days
+  , weeks
   , unsafeNanoseconds
   , unPreciseDuration
   , toNanoseconds
@@ -79,14 +86,14 @@ toString = case _ of
 
 negatePreciseDuration :: PreciseDuration -> PreciseDuration
 negatePreciseDuration = case _ of
-  Nanoseconds   x -> Nanoseconds   (negate x)
-  Microseconds  x -> Microseconds  (negate x)
-  Milliseconds  x -> Milliseconds  (negate x)
-  Seconds       x -> Seconds       (negate x)
-  Minutes       x -> Minutes       (negate x)
-  Hours         x -> Hours         (negate x)
-  Days          x -> Days          (negate x)
-  Weeks         x -> Weeks         (negate x)
+  Nanoseconds x -> Nanoseconds (negate x)
+  Microseconds x -> Microseconds (negate x)
+  Milliseconds x -> Milliseconds (negate x)
+  Seconds x -> Seconds (negate x)
+  Minutes x -> Minutes (negate x)
+  Hours x -> Hours (negate x)
+  Days x -> Days (negate x)
+  Weeks x -> Weeks (negate x)
 
 -- Smart constructors
 unsafeNanoseconds :: Decimal -> PreciseDuration
@@ -119,14 +126,14 @@ weeks = Weeks
 
 unPreciseDuration :: PreciseDuration -> Decimal
 unPreciseDuration = case _ of
-  Nanoseconds d  -> d
+  Nanoseconds d -> d
   Microseconds d -> d * micro
   Milliseconds d -> d * milli
-  Seconds d      -> d * second
-  Minutes d      -> d * minute
-  Hours d        -> d * hour
-  Days d         -> d * day
-  Weeks d        -> d * week
+  Seconds d -> d * second
+  Minutes d -> d * minute
+  Hours d -> d * hour
+  Days d -> d * day
+  Weeks d -> d * week
 
 -- Conversions
 toNanoseconds :: PreciseDuration -> PreciseDuration
@@ -173,11 +180,11 @@ toDecimalLossy = case _ of
   Weeks d -> d
 
 -- Each duration in nanoseconds
-nano   = Decimal.fromInt 1 :: Decimal
-micro  = (nano * Decimal.fromInt 1000) :: Decimal
-milli  = (micro * Decimal.fromInt 1000) :: Decimal
+nano = Decimal.fromInt 1 :: Decimal
+micro = (nano * Decimal.fromInt 1000) :: Decimal
+milli = (micro * Decimal.fromInt 1000) :: Decimal
 second = (milli * Decimal.fromInt 1000) :: Decimal
 minute = (second * Decimal.fromInt 60) :: Decimal
-hour   = (minute * Decimal.fromInt 60) :: Decimal
-day    = (hour * Decimal.fromInt 24) :: Decimal
-week   = (day * Decimal.fromInt 7) :: Decimal
+hour = (minute * Decimal.fromInt 60) :: Decimal
+day = (hour * Decimal.fromInt 24) :: Decimal
+week = (day * Decimal.fromInt 7) :: Decimal

--- a/test/Data/PreciseDateTime.purs
+++ b/test/Data/PreciseDateTime.purs
@@ -2,8 +2,8 @@ module Test.Data.PreciseDateTime.Spec where
 
 import Prelude
 
-import Data.Decimal (fromString)
 import Data.Date as Date
+import Data.Decimal (fromString)
 import Data.Enum (toEnum)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Newtype (class Newtype)
@@ -74,7 +74,7 @@ spec =
       fromRFC3339String (RFC3339String $ dateStringFixture <> ".1000000000Z")
         `shouldEqual` (Just $ preciseDateTimeFixture 100 0)
 
-    it"toRFC3339String" do
+    it "toRFC3339String" do
       toRFC3339String (preciseDateTimeFixture 0 0)
         `shouldEqual` (RFC3339String $ dateStringFixture <> ".0Z")
 
@@ -133,7 +133,6 @@ spec =
       diff (mkPreciseDateTime 1985 Date.March 5 23 59 59 999 999999) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (PD.unsafeNanoseconds <<< unsafePartial fromJust <<< fromString $ "-604800000000001")
 
-
     it "adjust" do
       adjust (PD.nanoseconds 0) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
@@ -147,7 +146,7 @@ spec =
       adjust (PD.nanoseconds 1000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 13 0 0 0 1 0)
 
-      adjust(PD.nanoseconds (-1000000)) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
+      adjust (PD.nanoseconds (-1000000)) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)
         `shouldEqual` (Just $ mkPreciseDateTime 1985 Date.March 12 23 59 59 999 0)
 
       adjust (PD.nanoseconds 10000000) (mkPreciseDateTime 1985 Date.March 13 0 0 0 0 0)

--- a/test/Data/Time/PreciseDuration.purs
+++ b/test/Data/Time/PreciseDuration.purs
@@ -63,5 +63,5 @@ spec =
       PD.toString (PD.toSeconds $ PD.nanoseconds 1) `shouldEqual` "0.000000001s"
       PD.toString (PD.toMinutes $ PD.nanoseconds 1) `shouldEqual` "0.00000000001666666667m"
       PD.toString (PD.toHours $ PD.nanoseconds 1) `shouldEqual` "0.00000000000027777778h"
-      PD.toString (PD.toDays $ PD.nanoseconds 1) `shouldEqual`  "0.00000000000001157407d"
+      PD.toString (PD.toDays $ PD.nanoseconds 1) `shouldEqual` "0.00000000000001157407d"
       PD.toString (PD.toWeeks $ PD.nanoseconds 1) `shouldEqual` "0.00000000000000165344w"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,4 +11,4 @@ import Test.Spec.Runner (runSpec)
 main :: Effect Unit
 main = launchAff_ do
   spec <- discover "Test\\..*\\.Spec"
-  runSpec [consoleReporter] spec
+  runSpec [ consoleReporter ] spec


### PR DESCRIPTION
This PR updates dependencies for PureScript 0.15. Code changes weren't required other than explicitly importing `aff-promise`, which must have previously been included transitively. However, because of the major dependency upgrade, the library needs a new major release as well.

This also introduces `purs-tidy`.